### PR TITLE
Fix exit on sass compile error

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,7 +32,7 @@ gulp.task('sass', function () {
     // initialize sourcemaps
     .pipe(sourcemaps.init())
     // pass the file through gulp-sass
-    .pipe(sass())
+    .pipe(sass()).on('error', swallowError)
     // pass the file through autoprefixer
     .pipe(prefix(['last 15 versions', '> 1%', 'ie 8', 'ie 7'], {cascade: true}))
     // add css sourcemaps
@@ -110,3 +110,21 @@ gulp.task('check:sasslint', function() {
  * compile Sass files, launch BrowserSync & watch files.
  */
 gulp.task('default', ['sass', 'watch']);
+
+/**
+ * Swallow errors
+ *
+ * Add `.on('error' swallowError)` after any .pipe() where you do not
+ * want gulp to exit as a result of the error condition.
+ * E.g.
+ *       .pipe(sass()).on('error', swallowError)
+ *
+ * @param error
+ */
+function swallowError (error) {
+
+  // If you want details of the error in the console
+  console.log(error.toString())
+
+  this.emit('end')
+}


### PR DESCRIPTION
issue #1: https://github.com/commonmedia/drupal-gulp-starter/issues/1

This PR adds an `on('error')` handler called `swallowError`, and applies it after the .pipe(sass()) call in the sass task definition. The `swallowError` function spits out the error message to the console, but permits the task to keep running.